### PR TITLE
fix create behavior of OutputFile

### DIFF
--- a/src/main/java/com/tideworks/data_load/io/OutputFile.java
+++ b/src/main/java/com/tideworks/data_load/io/OutputFile.java
@@ -13,11 +13,10 @@ import java.io.BufferedOutputStream;
 import java.io.IOException;
 import java.io.OutputStream;
 import java.nio.file.Files;
+import java.nio.file.OpenOption;
 import java.nio.file.Path;
 
-import static java.nio.file.StandardOpenOption.APPEND;
-import static java.nio.file.StandardOpenOption.CREATE;
-import static java.nio.file.StandardOpenOption.TRUNCATE_EXISTING;
+import static java.nio.file.StandardOpenOption.*;
 
 public final class OutputFile {
   private static final int IO_BUF_SIZE = 16 * 1024;
@@ -28,12 +27,12 @@ public final class OutputFile {
     return new org.apache.parquet.io.OutputFile() {
       @Override
       public PositionOutputStream create(long blockSizeHint) throws IOException {
-        return makePositionOutputStream(file, IO_BUF_SIZE, false);
+        return makePositionOutputStream(file, IO_BUF_SIZE, CREATE_NEW);
       }
 
       @Override
       public PositionOutputStream createOrOverwrite(long blockSizeHint) throws IOException {
-        return makePositionOutputStream(file, IO_BUF_SIZE, true);
+        return makePositionOutputStream(file, IO_BUF_SIZE, CREATE, TRUNCATE_EXISTING );
       }
 
       @Override
@@ -48,11 +47,11 @@ public final class OutputFile {
     };
   }
 
-  private static PositionOutputStream makePositionOutputStream(@Nonnull Path file, int ioBufSize, boolean trunc)
+  private static PositionOutputStream makePositionOutputStream(@Nonnull Path file, int ioBufSize, OpenOption... options)
           throws IOException
   {
     final OutputStream output = new BufferedOutputStream(
-            Files.newOutputStream(file, CREATE, trunc ? TRUNCATE_EXISTING : APPEND), ioBufSize);
+            Files.newOutputStream(file, options), ioBufSize);
 
     return new PositionOutputStream() {
       private long position = 0;

--- a/src/test/java/com/tideworks/data_load/io/OutputFileTest.java
+++ b/src/test/java/com/tideworks/data_load/io/OutputFileTest.java
@@ -1,0 +1,39 @@
+package com.tideworks.data_load.io;
+
+import com.google.common.io.Files;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+import org.junit.rules.TemporaryFolder;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.FileAlreadyExistsException;
+
+import static org.junit.Assert.*;
+
+public class OutputFileTest {
+
+    @Rule
+    public ExpectedException exceptionRule = ExpectedException.none();
+
+    @Rule
+    public TemporaryFolder folder= new TemporaryFolder();
+
+
+    @Test
+    public void testCreate_ErrorIfFileCreated() throws IOException {
+        File file = folder.newFile("test.file");
+
+        exceptionRule.expect(FileAlreadyExistsException.class);
+        OutputFile.nioPathToOutputFile(file.toPath()).create(10);
+    }
+
+    @Test
+    public void testCreateOrOverride_Truncate() throws IOException {
+        File file = folder.newFile("override.file");
+        Files.write(new byte[10], file);
+        OutputFile.nioPathToOutputFile(file.toPath()).createOrOverwrite(10);
+        assertEquals(0, file.length());
+    }
+}


### PR DESCRIPTION
expected: create must throw an error if file already exists
actual: file is appended. In case you run write to to file more than
once then OutputFile will append data to the same file making the output
file unusable